### PR TITLE
Some Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/assets.go
+/zgencomp

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ deps:
 	go get github.com/jteeuwen/go-bindata/...
 
 install: deps
-	go-bindata -o=assets.go ./data/...
+	go-bindata -o=assets.go ./data/templates/
 	go install

--- a/data/templates/sample.tpl
+++ b/data/templates/sample.tpl
@@ -9,10 +9,18 @@ function _{{.Command}}() {
     local ret=1
 
     _arguments -C \
+      {{if .Properties.Help.Option -}}
         '{{.Properties.Help.Option | dealWithExclusion}}{{.Properties.Help.Option | dealWithOption}}[{{.Properties.Help.Description | dealWithDescription}}]' \
-        '{{.Properties.Version.Option | dealWithExclusion}}{{.Properties.Version.Option | dealWithOption}}[{{.Properties.Version.Description | dealWithDescription}}]' \{{range .Options.Switch}}{{if .Option | whetherOptionIsEnabled}}
-        '{{.| dealWithSwitchExclusion}}{{.| dealWithSwitchOption}}[{{.Description | dealWithDescription}}]' \{{end}}{{end}}{{range .Options.Flag}}{{if .Option | whetherOptionIsEnabled}}
-        '{{.| dealWithFlagExclusion}}{{.| dealWithFlagOption}}[{{.Description | dealWithDescription}}]:{{.| setFlagMessage}}:{{.| setAction}}' \{{end}}{{end}}
+      {{end -}}
+      {{if .Properties.Version.Option -}}
+        '{{.Properties.Version.Option | dealWithExclusion}}{{.Properties.Version.Option | dealWithOption}}[{{.Properties.Version.Description | dealWithDescription}}]' \
+      {{end -}}
+      {{range .Options.Switch -}}
+        '{{.| dealWithSwitchExclusion}}{{.| dealWithSwitchOption}}[{{.Description | dealWithDescription}}]' \
+      {{end -}}
+      {{range .Options.Flag -}}
+        '{{.| dealWithFlagExclusion}}{{.| dealWithFlagOption}}[{{.Description | dealWithDescription}}]:{{.| setFlagMessage}}:{{.| setAction}}' \
+      {{end -}}
         '{{if not .Arguments.After_arg}}(-){{end}}*:arguments:{{.Arguments.Type | setAction}}' \
         && ret=0
 

--- a/data/templates/sample.tpl
+++ b/data/templates/sample.tpl
@@ -21,9 +21,12 @@ function _{{.Command}}() {
       {{range .Options.Flag -}}
         '{{.| dealWithFlagExclusion}}{{.| dealWithFlagOption}}[{{.Description | dealWithDescription}}]:{{.| setFlagMessage}}:{{.| setAction}}' \
       {{end -}}
+      {{if .Arguments -}}
         '{{if not .Arguments.After_arg}}(-){{end}}*:arguments:{{.Arguments.Type | setAction}}' \
+      {{end -}}
         && ret=0
 
+  {{if .Arguments -}}
     case $state in
         {{range .Options.Flag}}{{if .Option | whetherOptionIsEnabled}}{{if .Argument.Type | whetherTypeIsFunc}}{{.| setAction | helperTrimArrowInType}})
           # TODO
@@ -32,6 +35,7 @@ function _{{.Command}}() {
           # TODO
           ;;{{end}}
     esac
+  {{end -}}
 
     return ret
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ type JsonData struct {
 	Command    string     `json:"command"`
 	Properties Properties `json:"properties"`
 	Options    Options    `json:"options"`
-	Arguments  Arguments  `json:"arguments"`
+	Arguments  *Arguments `json:"arguments"`
 }
 
 type Properties struct {

--- a/main.go
+++ b/main.go
@@ -201,7 +201,7 @@ func generateSampleJson(f string) (err error) {
 		}
 	}
 
-	ioutil.WriteFile(f, data, os.ModePerm)
+	ioutil.WriteFile(f, data, 0644)
 	return
 }
 


### PR DESCRIPTION
Thanks for great tool!

Sorry, this PR has multiple changes.

Add .gitignore
----

ed63428

I've added a .gitignore file to avoid git-add generated files.


Avoid invalid script without help and version options
-------

fcbd53f

When `help` and `version` options do not exist, zgencomp generates invalid code as shell script.

For example

```json
{
    "command" : "mycmd",

    "properties" : {
        "author" : "John Doe",
        "license" : "MIT"
    },

    "options" : {
        "switch" : [
            {
                "option" : [
                    "-c",
                    "--count"
                ],
                "description" : "Only a count of selected lines is written to standard output.",
                "exclusion" : [
                ]
            },
            {
                "option" :  [
                ],
                "description" : ""
            }
        ],
        "flag" : [
            {
                "option" : [
                    "-m",
                    "--max-count"
                ],
                "description" : "Stop reading the file after num matches.",
                "exclusion" : [
                    "-c",
                    "--count"
                ],
                "argument" : {
                    "group" : "",
                    "type" : "func",
                    "style" : {
                            "standard" : ["-m"],
                            "touch" : [],
                            "touchable" : [],
                            "equal" : ["--max--count"],
                            "equalable" : []
                    }
                }
            },
            {
                "option" : [
                ],
                "description" : "",
                "exclusion" : [
                ],
                "argument": {
                    "group" : "",
                    "type" : "",
                    "style" : {
                        "standard" : [],
                        "touch" : [],
                        "touchable" : [],
                        "equal" : [],
                        "equalable" : []
                    }
                }
            }
        ]
    },

    "arguments" : {
        "always" : true,
        "type" : "func"
    }
}
```

```sh
$ compdef mycmd

# Copyright (c) 2016 John Doe
# License: MIT

function _mycmd() {
    local context curcontext=$curcontext state line
    typeset -A opt_args
    local ret=1

    _arguments -C \
        '()'{}'[]' \
        '()'{}'[]' \
        '(-c --count)'{-c,--count}'[Only a count of selected lines is written to standard output.]' \
        '(-m --max-count -c --count)'{-m,--max-count}'[Stop reading the file after num matches.]: :->m_func' \
        '(-)*:arguments:->args' \
        && ret=0

    case $state in
        m_func)
          # TODO
          ;;
        args)
          # TODO
          ;;
    esac

    return ret
}

_mycmd "$@"
```

`'()'{}'[]'` is generated, and it's invalid.

This change avoids the problem. If the options don't exist, zgencomp doesn't generate any code for the options.


Avoid crash without Arguments
-----

39860aa

zgencomp crashes without `Arguments` option.

For example.

```json
{
    "command" : "mycmd",

    "properties" : {
        "author" : "John Doe",
        "license" : "MIT",
        "help" : {
            "option" : [
                "--help"
            ],

            "description" : "Print a brief help message."
        },
        "version" : {
            "option" : [
                "-V",
                "--version"
            ],
            "description" : "Display version information and exit."
        }
    },

    "options" : {
        "switch" : [
            {
                "option" : [
                    "-c",
                    "--count"
                ],
                "description" : "Only a count of selected lines is written to standard output.",
                "exclusion" : [
                ]
            },
            {
                "option" :  [
                ],
                "description" : ""
            }
        ],
        "flag" : [
            {
                "option" : [
                    "-m",
                    "--max-count"
                ],
                "description" : "Stop reading the file after num matches.",
                "exclusion" : [
                    "-c",
                    "--count"
                ],
                "argument" : {
                    "group" : "",
                    "type" : "func",
                    "style" : {
                            "standard" : ["-m"],
                            "touch" : [],
                            "touchable" : [],
                            "equal" : ["--max--count"],
                            "equalable" : []
                    }
                }
            },
            {
                "option" : [
                ],
                "description" : "",
                "exclusion" : [
                ],
                "argument": {
                    "group" : "",
                    "type" : "",
                    "style" : {
                        "standard" : [],
                        "touch" : [],
                        "touchable" : [],
                        "equal" : [],
                        "equalable" : []
                    }
                }
            }
        ]
    }
}
```

```sh
$ compdef mycmd

# Copyright (c) 2016 John Doe
# License: MIT

function _mycmd() {
    local context curcontext=$curcontext state line
    typeset -A opt_args
    local ret=1

    _arguments -C \
        '(--help)--help[Print a brief help message.]' \
        '(-V --version)'{-V,--version}'[Display version information and exit.]' \
        '(-c --count)'{-c,--count}'[Only a count of selected lines is written to standard output.]' \
        '(-m --max-count -c --count)'{-m,--max-count}'[Stop reading the file after num matches.]: :->m_func' \
        '(-)*:arguments:template: scan:16:82: executing "scan" at <setAction>: wrong number of args for setAction: want 1 got 0
```

I've fixed the problem.



Do not contain gif animation file for demo
------

92f61fe

zgencomp binary has GIF animation for dmeo in assets.go

This change avoid the problem.


The file size has been reduced from 4.1 MB to 3.8 MB.


Fix generated sample.json permission
-------

Generated `sample.json` permission is `755`. I think `+x` permission is unnecessary.

I've changed the permission to `644`.